### PR TITLE
dcr.stakepool.net is now dcr.blue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ tmp
 dcrwebapi
 .DS_Store
 vendor/ 
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2017-2018 The Decred developers
+Copyright (c) 2017-2019 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/service.go
+++ b/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 The Decred developers
+// Copyright (c) 2017-2019 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -175,7 +175,7 @@ func NewService() *Service {
 			"Bravo": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",
-				URL:                  "https://dcr.stakepool.net",
+				URL:                  "https://dcr.blue",
 				Launched:             getUnixTime(2016, 5, 22, 22, 54),
 			},
 			"Delta": {


### PR DESCRIPTION
Update the URL for VSP Bravo from "https://dcr.stakepool.net" to "https://dcr.blue".