### PR TITLE
re-add dcr.stakepool.net as Bravo old

### DIFF
--- a/service.go
+++ b/service.go
@@ -178,6 +178,12 @@ func NewService() *Service {
 				URL:                  "https://dcr.blue",
 				Launched:             getUnixTime(2016, 5, 22, 22, 54),
 			},
+			"Bravo-old": {
+				APIVersionsSupported: []interface{}{},
+				Network:              "mainnet",
+				URL:                  "https://dcr.stakepool.net",
+				Launched:             getUnixTime(2016, 5, 22, 22, 54),
+			},
 			"Delta": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",


### PR DESCRIPTION
Removing a stakepool with a URL that was a configured pool in
Decrediton may be causing issues.  Re-add the original Bravo url
so that Decrediton will find the stake pool again.

DO NOT MERGE until @alexlyp has a chance to check how Decrediton behaves regarding existing configurations that reference pools no longer listed by the web api.