### PR TITLE
remove dcr.pos.fans

### DIFF
--- a/service.go
+++ b/service.go
@@ -254,12 +254,6 @@ func NewService() *Service {
 				URL:                  "https://decred.raqamiya.net",
 				Launched:             getUnixTime(2017, 12, 21, 17, 50),
 			},
-			"Oscar": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://pos.dcr.fans",
-				Launched:             getUnixTime(2017, 12, 21, 17, 50),
-			},
 			"Papa": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",


### PR DESCRIPTION
Service has proven to be unreliable - repeatedly gone offline, a very high miss rate, and not contactable.