### PR TITLE
Remove VSPs with broken registration.

### DIFF
--- a/service.go
+++ b/service.go
@@ -266,23 +266,11 @@ func NewService() *Service {
 				URL:                  "https://test.stakey.net",
 				Launched:             getUnixTime(2018, 1, 22, 21, 04),
 			},
-			"Ray": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://dcrpos.idcray.com",
-				Launched:             getUnixTime(2018, 2, 12, 14, 44),
-			},
 			"Sierra": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",
 				URL:                  "https://decredvoting.com",
 				Launched:             getUnixTime(2018, 8, 30, 11, 55),
-			},
-			"Ethan": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://tokensmart.io",
-				Launched:             getUnixTime(2018, 4, 2, 16, 44),
 			},
 			"Life": {
 				APIVersionsSupported: []interface{}{},


### PR DESCRIPTION
These two VSPs have had broken registration (email errors) since at least December 19th. There have been multiple attempts to contact the operators.

https://tokensmart.io was added in #23 by @qukuailianyonghu
https://dcrpos.idcray.com was added in #17 by @saymissme