### PR TITLE
Remove staked.us VSP

### DIFF
--- a/service.go
+++ b/service.go
@@ -296,12 +296,6 @@ func NewService() *Service {
 				URL:                  "https://dcrstake.coinmine.pl",
 				Launched:             getUnixTime(2018, 10, 22, 22, 30),
 			},
-			"Staked": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://decred.staked.us",
-				Launched:             getUnixTime(2018, 11, 28, 19, 30),
-			},
 			"Tango": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "testnet",


### PR DESCRIPTION
This PR removes staked.us VSP.

https://decred.staked.us

Registration is not possible on the site, seemingly because the mail server is not working.

On top of this, the operator @sriney-staked is not on Matrix in our pos-ops channel afaik.