### PR TITLE
Remove coinmine.pl VSP

### DIFF
--- a/service.go
+++ b/service.go
@@ -290,12 +290,6 @@ func NewService() *Service {
 				URL:                  "https://dcrpos.megapool.info",
 				Launched:             getUnixTime(2018, 10, 20, 9, 30),
 			},
-			"Zeta": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://dcrstake.coinmine.pl",
-				Launched:             getUnixTime(2018, 10, 22, 22, 30),
-			},
 			"Staked": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",


### PR DESCRIPTION
This PR removes coinmin.pl VSP.

https://dcrstake.coinmine.pl/

The site is returning an error when I try and add a pubkeyaddr to an account.

On top of this, the operator @feeleep75 is not on Matrix in our pos-ops channel afaik.