### PR TITLE
Remove stakepool.eu VSP

### DIFF
--- a/service.go
+++ b/service.go
@@ -218,12 +218,6 @@ func NewService() *Service {
 				URL:                  "https://stake.decredbrasil.com",
 				Launched:             getUnixTime(2016, 5, 28, 19, 31),
 			},
-			"India": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://stakepool.eu",
-				Launched:             getUnixTime(2016, 5, 22, 18, 58),
-			},
 			"Juliett": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",


### PR DESCRIPTION
This PR removes stakepool.eu VSP.

https://stakepool.eu/

The site is running very old code (vote version 6) - likely forked from the network at this point.
The site is returning an error when I try and add a pubkeyaddr to an account.
