### PR TITLE
Remove raqamiya.net VSP

### DIFF
--- a/service.go
+++ b/service.go
@@ -248,12 +248,6 @@ func NewService() *Service {
 				URL:                  "https://dcr.farm",
 				Launched:             getUnixTime(2017, 12, 21, 17, 50),
 			},
-			"November": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://decred.raqamiya.net",
-				Launched:             getUnixTime(2017, 12, 21, 17, 50),
-			},
 			"Papa": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",


### PR DESCRIPTION
CSRF error is being shown when attempting to add a pubkeyaddr to a new account:

```Forbidden - CSRF token invalid```

Operator `@utyosov:decred.org` has been notified on Matrix but not responded.