### PR TITLE
vspd domain correction

### DIFF
--- a/service.go
+++ b/service.go
@@ -186,7 +186,7 @@ func NewService() *Service {
 				Network:  "testnet",
 				Launched: getUnixTime(2020, 7, 30),
 			},
-			"test.stakey.net/incognito": Vsp{
+			"test.stakey.net": Vsp{
 				Network:  "testnet",
 				Launched: getUnixTime(2020, 7, 31),
 			},


### PR DESCRIPTION
Location directives allowing dcrstakepool and vspd to co-exist on the same domain do not (and actually have never) required moving api endpoints. See nginx samples provided in vspd issue #159. The invalid api path has been deprecated and removed.