### PR TITLE
Add ultravsp.uk

### DIFF
--- a/service.go
+++ b/service.go
@@ -206,6 +206,10 @@ func NewService() *Service {
 				Network:  "mainnet",
 				Launched: getUnixTime(2020, 11, 22),
 			},
+			"ultravsp.uk": Vsp{
+				Network: "mainnet",
+				Launched: getUnixTime(2020, 12, 1),
+			},
 		},
 
 		// Historical launch dates have been collected from these sources:

--- a/service.go
+++ b/service.go
@@ -207,7 +207,7 @@ func NewService() *Service {
 				Launched: getUnixTime(2020, 11, 22),
 			},
 			"ultravsp.uk": Vsp{
-				Network: "mainnet",
+				Network:  "mainnet",
 				Launched: getUnixTime(2020, 12, 1),
 			},
 		},


### PR DESCRIPTION
VSPD has now had a vote! 

https://ultravsp.uk/

This is the vspd version of ultrapool.eu . Due to Brexit uncertainty I'm moving to a .uk domain name in case something unexpected happpens and I get forced to change domain names later.