### PR TITLE
Changed ultrapool.eu -> legacy.ultravsp.uk

### DIFF
--- a/service.go
+++ b/service.go
@@ -280,7 +280,7 @@ func NewService() *Service {
 			"Lima": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",
-				URL:                  "https://ultrapool.eu",
+				URL:                  "https://legacy.ultravsp.uk",
 				Launched:             getUnixTime(2017, 5, 23),
 			},
 			"Mike": {


### PR DESCRIPTION
Brexit is going to mean that ultrapool.eu will stop resolving in the new year, so can you update this to point to it's new DNS entry.

Thanks.