### PR TITLE
Remove VSP operators who haven't updated to vspd.

### DIFF
--- a/service.go
+++ b/service.go
@@ -257,12 +257,6 @@ func NewService() *Service {
 				URL:                  "https://pool.d3c.red",
 				Launched:             getUnixTime(2016, 5, 23),
 			},
-			"Golf": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://stakepool.dcrstats.com",
-				Launched:             getUnixTime(2016, 5, 25),
-			},
 			"Hotel": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",
@@ -352,12 +346,6 @@ func NewService() *Service {
 				Network:              "mainnet",
 				URL:                  "https://99split.com",
 				Launched:             getUnixTime(2019, 12, 17),
-			},
-			"Charlie": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://decred.yieldwallet.io",
-				Launched:             getUnixTime(2020, 1, 29),
 			},
 			"Dinner": {
 				APIVersionsSupported: []interface{}{},


### PR DESCRIPTION
The following operators have not been active in the community for some time, and show no signs of upgrading to vspd. Between them they currently hold 303 live tickets.

- @dyrk (https://stakepool.dcrstats.com)
- @tpruvot (https://stakepool.eu)
- @gsampathkumar (https://yieldwallet.io)
