### PR TITLE
Remove legacy VSP decredvoting.com

### DIFF
--- a/service.go
+++ b/service.go
@@ -319,12 +319,6 @@ func NewService() *Service {
 				URL:                  "https://test.stakey.net",
 				Launched:             getUnixTime(2018, 1, 22),
 			},
-			"Sierra": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://decredvoting.com",
-				Launched:             getUnixTime(2018, 8, 30),
-			},
 			"Life": {
 				APIVersionsSupported: []interface{}{},
 				Network:              "mainnet",
@@ -336,12 +330,6 @@ func NewService() *Service {
 				Network:              "mainnet",
 				URL:                  "https://dcrstake.coinmine.pl",
 				Launched:             getUnixTime(2018, 10, 22),
-			},
-			"Tango": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "testnet",
-				URL:                  "https://testnet.decredvoting.com",
-				Launched:             getUnixTime(2018, 8, 30),
 			},
 			"99split": {
 				APIVersionsSupported: []interface{}{},


### PR DESCRIPTION
@David00 mentioned on Matrix that he has taken down his dcrstakepool deployment, but he is still running the voting wallets to ensure all currently live tickets will be voted.

Part of #138 