### PR TITLE
Update to golangci-lint 1.40.1.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1"
       - name: Build
         env:
           GO111MODULE: "on"
@@ -23,4 +23,4 @@ jobs:
       - name: Test
         env:
           GO111MODULE: "on"
-        run: golangci-lint run --disable-all --deadline=10m --enable=gofmt --enable=golint --enable=vet --enable=gosimple --enable=unconvert
+        run: golangci-lint run --disable-all --deadline=10m --enable=gofmt --enable=revive --enable=vet --enable=gosimple --enable=unconvert


### PR DESCRIPTION
Linter `golint` has been deprecated and replaced with `revive`.