### PR TITLE
Remove legacy 99split VSP.

### DIFF
--- a/service.go
+++ b/service.go
@@ -305,12 +305,6 @@ func NewService() *Service {
 				URL:                  "https://dcrstake.coinmine.pl",
 				Launched:             getUnixTime(2018, 10, 22),
 			},
-			"99split": {
-				APIVersionsSupported: []interface{}{},
-				Network:              "mainnet",
-				URL:                  "https://99split.com",
-				Launched:             getUnixTime(2019, 12, 17),
-			},
 		},
 	}
 


### PR DESCRIPTION
Reporting zero live/immature tickets.

FYI @99split 