### PR TITLE
Remove decredvoting.com

### DIFF
--- a/service.go
+++ b/service.go
@@ -194,10 +194,6 @@ func NewService() *Service {
 				Network:  "mainnet",
 				Launched: getUnixTime(2020, 12, 9),
 			},
-			"decredvoting.com": Vsp{
-				Network:  "mainnet",
-				Launched: getUnixTime(2021, 2, 1),
-			},
 			"vsp.coinmine.pl": Vsp{
 				Network:  "mainnet",
 				Launched: getUnixTime(2021, 1, 28),


### PR DESCRIPTION
The only VSP which hasnt updated to [vspd 1.2.0](https://github.com/decred/vspd/releases/tag/release-v1.2.0).

I haven't been able to reach @David00 over Matrix or email, so hopefully this will grab his attention.