### PR TITLE
Change coinmine.pl URL to decred.stake.fun

### DIFF
--- a/service.go
+++ b/service.go
@@ -104,7 +104,7 @@ func NewService() *Service {
 				Network:  "mainnet",
 				Launched: getUnixTime(2021, 2, 1),
 			},
-			"vsp.coinmine.pl": Vsp{
+			"decred.stake.fun": Vsp{
 				Network:  "mainnet",
 				Launched: getUnixTime(2021, 1, 28),
 			},


### PR DESCRIPTION
I noticed the old URL is now redirecting to https://decred.stake.fun and the branding on their site also reflects the change.

@feeleep75 could you please confirm this change?
