### PR TITLE
Remove 123.dcr.rocks

### DIFF
--- a/service.go
+++ b/service.go
@@ -110,10 +110,6 @@ func NewService() *Service {
 				Network:  "mainnet",
 				Launched: getUnixTime(2021, 1, 28),
 			},
-			"123.dcr.rocks": {
-				Network:  "mainnet",
-				Launched: getUnixTime(2021, 4, 28),
-			},
 			"big.decred.energy": {
 				Network:  "mainnet",
 				Launched: getUnixTime(2022, 5, 1),


### PR DESCRIPTION
Unfortunately we have to shut down our VSP. As soon as 123.dcr.rocks has been removed from the list we will stop accepting new tickets and then shut down the servers in a few months once all live tickets have been voted. 