### PR TITLE
remove decred.stake.fun VSP

### DIFF
--- a/service.go
+++ b/service.go
@@ -130,10 +130,6 @@ func NewService() *Service {
 				Network:  "mainnet",
 				Launched: getUnixTime(2021, 2, 1),
 			},
-			"decred.stake.fun": Vsp{
-				Network:  "mainnet",
-				Launched: getUnixTime(2021, 1, 28),
-			},
 			"big.decred.energy": {
 				Network:  "mainnet",
 				Launched: getUnixTime(2022, 5, 1),


### PR DESCRIPTION
This PR removes decred.stake.fun from the official VSP listing as their voting wallets not voting for a while causing users to miss their votes.

@feeleep75  your VSP is up for removal since your VSP is behind the chain and last status reporting was on Dec 9th.